### PR TITLE
Fix widget not loading

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,7 +27,7 @@ export default class WidgetBot extends React.PureComponent<Props> {
     server: '299881420891881473',
     shard: 'https://e.widgetbot.io',
     options: {},
-    defer: true,
+    defer: false,
     focusable: true
   }
 


### PR DESCRIPTION
Set defer false by default. True caused `src` to be `unknown`